### PR TITLE
Release 1.6148: broken-link checker overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to **External Link Control by thisismyurl.com** are recorded here. The plugin uses a `x.Yddd` Julian-day version scheme: `x` is the release class (`0` = pre-release, `1` = full), `Y` is the last digit of the year, and `ddd` is the day of year (001-366).
 
+## 1.6148 — 2026-05-27
+
+Broken-link checker overhaul. Addresses the un-dismissable notice, false positives on bot-blocked hosts, and the lack of any way to mute links the owner does not care about.
+
+### Fixed
+- **The dismiss button now persists.** The plugin shipped no JavaScript, so the core `is-dismissible` "X" only removed the notice from the DOM for the current page load — the AJAX dismiss endpoint that flips the stored flag was never called, and the notice returned on the next admin screen. A small `assets/js/admin.js` now records the dismissal server-side.
+- **Dismissals are remembered per link set, not globally.** The results option now stores a `dismissed_urls` fingerprint instead of a single boolean. The notice only reappears when a later scan finds a broken URL that was not in the dismissed set — recurring known-broken links stay quiet until they are fixed or a genuinely new break appears. The scan no longer blindly resets the dismissed flag on every run.
+- **Far fewer false positives.** Classification now sorts results into `broken` (404, 410, or a dead domain whose host no longer resolves) versus `unverified` (401/403/405/429/451/999, other non-2xx/3xx, and transient network errors such as timeouts and TLS failures). Only `broken` raises the notice. LinkedIn (405 to HEAD) and time.com (403 to bots) no longer count as broken.
+- **HEAD-hostile servers get a GET retry.** A HEAD that returns 400/403/405/406/501 or errors is retried once with `GET` (asking for a single byte via `Range`) before any verdict, so servers and CDNs that reject HEAD stop registering as broken.
+
+### Added
+- **Ignore list** (`timu_elc_broken_link_ignored`). An "Ignore" action on each link in the dashboard widget mutes a URL or a whole host; ignored entries are skipped at collection time, so they cost no request and never surface. A "Stop ignoring" action and an "Ignored" section round out management from the same widget.
+- **"Scan now" button** in the dashboard widget. Schedules the check to run immediately (spawns cron; falls back to an inline run when `DISABLE_WP_CRON` is set) instead of waiting for the weekly event.
+- **"Could not verify" section** in the widget surfaces the `unverified` bucket for transparency without alarming.
+- **Per-link "Recheck"** re-tests a single URL on demand and moves it to the correct bucket.
+- **`timu_elc_broken_status_codes` filter** to tune which HTTP codes count as broken (defaults to `[404, 410]`).
+
+### Notes
+- The dashboard widget's JS and the shared admin CSS now enqueue admin-wide for `manage_options` users (the notice can appear on any screen). The asset is small and capability-gated.
+- All AJAX actions (dismiss, ignore, unignore, recheck, scan-now) are nonce-verified (`timu_elc_link_actions`) and capability-gated.
+
+## 1.6147 — 2026-05-27
+
+### Changed
+- Unified plugin versioning to the `x.Yddd` calendar-version scheme.
+- Confirmed compatibility with WordPress 7.0.
+
 ## 1.6143 — 2026-05-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -9,12 +9,24 @@ Control outbound link behaviour across your WordPress site — adding `nofollow`
 - Enable or disable external link filtering globally from one settings screen.
 - Open external links in a new tab with `target="_blank"`.
 - Add `rel="nofollow noopener noreferrer"` to external links automatically.
+- Monitor outbound links for breakage on a weekly schedule, with an ignore list, an on-demand "Scan now", and a dashboard widget.
 - Leaves your database content untouched — all changes happen during output rendering.
 - Internal links are always left alone.
 
 ## How it works
 
 The plugin hooks into the `the_content` filter and rewrites only external `http` and `https` links during rendering. No post content is stored differently; your editorial data stays clean.
+
+## Broken-link monitoring
+
+A weekly background scan checks your external links and reports the results in a **Tools → dashboard** widget. It is built to be honest about what "broken" means:
+
+- **Only genuine breaks raise a notice.** A link counts as broken when it returns `404`, `410`, or its domain no longer resolves. Responses that simply block automated checks — `401`, `403`, `405`, `429`, `451`, `999`, rate limits, and server hiccups — are listed under "Could not verify" instead, never as broken. (LinkedIn answering `405` to a `HEAD` request is the classic false positive this avoids.)
+- **HEAD-hostile servers get a GET retry.** If a `HEAD` request fails, the checker retries once with a ranged `GET` before deciding, so CDNs and servers that reject `HEAD` are not mislabelled.
+- **Dismissals stick.** Dismissing the notice records exactly which links were dismissed; it only returns when a later scan finds a link that was not in the dismissed set, rather than every time the same known links recur.
+- **An ignore list.** Mute any URL or whole host with one click; ignored links are skipped during the scan entirely. "Scan now" and per-link "Recheck" let you verify on demand.
+
+Tune which status codes count as broken with the `timu_elc_broken_status_codes` filter (defaults to `404` and `410`).
 
 ## Requirements
 

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -37,3 +37,72 @@
 	vertical-align: middle;
 }
 
+/* Broken-links dashboard widget (since 1.6148). */
+.timu-elc-widget h4 {
+	margin: 1.2em 0 0.2em;
+}
+
+.timu-elc-widget .timu-elc-unverified-head,
+.timu-elc-widget .timu-elc-ignored-head {
+	color: #646970;
+}
+
+.timu-elc-widget .timu-elc-clear {
+	color: #007017;
+	font-weight: 600;
+}
+
+.timu-elc-actions {
+	margin: 0.6em 0;
+}
+
+.timu-elc-actions .timu-elc-status {
+	margin-left: 0.6em;
+	color: #646970;
+	font-style: italic;
+}
+
+.timu-elc-link-list {
+	margin: 0.2em 0 0;
+}
+
+.timu-elc-link-list li {
+	padding: 0.35em 0;
+	border-top: 1px solid #f0f0f1;
+	word-break: break-word;
+}
+
+.timu-elc-link-list code {
+	background: transparent;
+	padding: 0;
+}
+
+.timu-elc-link-list .timu-elc-code {
+	color: #646970;
+	font-size: 0.9em;
+	white-space: nowrap;
+}
+
+.timu-elc-link-list.timu-elc-broken .timu-elc-code {
+	color: #b32d2e;
+}
+
+.timu-elc-row-actions {
+	display: inline-block;
+	margin-left: 0.4em;
+	white-space: nowrap;
+}
+
+.timu-elc-row-actions .button-link {
+	color: #2271b1;
+}
+
+.timu-elc-row-actions .timu-elc-ignore {
+	color: #646970;
+}
+
+.timu-elc-link-list .timu-elc-more {
+	border-top: 1px solid #f0f0f1;
+	color: #646970;
+}
+

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,0 +1,152 @@
+/**
+ * External Link Control — admin behaviour for the broken-link notice and the
+ * dashboard widget.
+ *
+ * Two jobs core WordPress does not do for us:
+ *
+ *   1. Persist the notice dismissal. Core's `is-dismissible` X only removes the
+ *      notice from the DOM for the current page load; it never tells the
+ *      server. We listen for that click and POST to the dismiss action so the
+ *      dismissal sticks until a later scan finds a link that wasn't dismissed.
+ *   2. Back the widget buttons — Scan now, Ignore, Stop ignoring, Recheck.
+ *
+ * Vanilla JS, no jQuery dependency. Config arrives via wp_localize_script as
+ * `window.timuElc` ({ ajaxUrl, nonce, i18n }).
+ */
+( function () {
+	'use strict';
+
+	if ( typeof window.timuElc === 'undefined' ) {
+		return;
+	}
+
+	var cfg = window.timuElc;
+
+	/**
+	 * POST an action to admin-ajax and return the parsed JSON promise.
+	 *
+	 * @param {string} action  The wp_ajax_{action} name.
+	 * @param {Object} [extra] Additional form fields.
+	 * @return {Promise<Object>}
+	 */
+	function post( action, extra ) {
+		var body = new URLSearchParams();
+		body.set( 'action', action );
+		body.set( 'nonce', cfg.nonce );
+		if ( extra ) {
+			Object.keys( extra ).forEach( function ( key ) {
+				body.set( key, extra[ key ] );
+			} );
+		}
+		return fetch( cfg.ajaxUrl, {
+			method: 'POST',
+			credentials: 'same-origin',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body: body.toString(),
+		} ).then( function ( r ) {
+			return r.json();
+		} );
+	}
+
+	/* -------------------------------------------------------------------
+	 * 1. Persist notice dismissal.
+	 * ----------------------------------------------------------------- */
+	document.addEventListener( 'click', function ( event ) {
+		var btn = event.target.closest( '.timu-elc-broken-notice .notice-dismiss' );
+		if ( ! btn ) {
+			return;
+		}
+		// Core removes the notice from the DOM itself; we just record it.
+		post( 'timu_elc_dismiss_notice' );
+	} );
+
+	/* -------------------------------------------------------------------
+	 * 2. Dashboard widget actions (event-delegated so they survive AJAX
+	 *    re-renders of the list).
+	 * ----------------------------------------------------------------- */
+	var widget = document.getElementById( 'timu-elc-broken-links' );
+	if ( ! widget ) {
+		return;
+	}
+
+	function setStatus( message ) {
+		var el = widget.querySelector( '.timu-elc-status' );
+		if ( el ) {
+			el.textContent = message || '';
+		}
+	}
+
+	widget.addEventListener( 'click', function ( event ) {
+		var target = event.target;
+
+		// Scan now.
+		if ( target.closest( '.timu-elc-scan-now' ) ) {
+			event.preventDefault();
+			var scanBtn = target.closest( '.timu-elc-scan-now' );
+			scanBtn.disabled = true;
+			setStatus( cfg.i18n.scanning );
+			post( 'timu_elc_scan_now' ).then( function ( res ) {
+				if ( ! res || ! res.success ) {
+					setStatus( cfg.i18n.scanError );
+					scanBtn.disabled = false;
+				}
+				// Leave the "scanning…" message; the owner refreshes to see results.
+			} ).catch( function () {
+				setStatus( cfg.i18n.scanError );
+				scanBtn.disabled = false;
+			} );
+			return;
+		}
+
+		var row = target.closest( 'li[data-url]' );
+		if ( ! row ) {
+			return;
+		}
+		var url = row.getAttribute( 'data-url' );
+
+		// Ignore.
+		if ( target.closest( '.timu-elc-ignore' ) ) {
+			event.preventDefault();
+			post( 'timu_elc_ignore_link', { url: url } ).then( function ( res ) {
+				if ( res && res.success ) {
+					row.parentNode.removeChild( row );
+				}
+			} );
+			return;
+		}
+
+		// Stop ignoring.
+		if ( target.closest( '.timu-elc-unignore' ) ) {
+			event.preventDefault();
+			post( 'timu_elc_unignore_link', { url: url } ).then( function ( res ) {
+				if ( res && res.success ) {
+					row.parentNode.removeChild( row );
+				}
+			} );
+			return;
+		}
+
+		// Recheck a single URL.
+		if ( target.closest( '.timu-elc-recheck' ) ) {
+			event.preventDefault();
+			var codeEl = row.querySelector( '.timu-elc-code' );
+			if ( codeEl ) {
+				codeEl.textContent = cfg.i18n.rechecking;
+			}
+			post( 'timu_elc_recheck_link', { url: url } ).then( function ( res ) {
+				if ( res && res.success ) {
+					if ( res.data.verdict === 'ok' ) {
+						// No longer a problem — drop the row.
+						row.parentNode.removeChild( row );
+					} else if ( codeEl ) {
+						codeEl.textContent = 'HTTP ' + ( res.data.status || 'error' );
+						row.setAttribute( 'data-verdict', res.data.verdict );
+					}
+				} else if ( codeEl ) {
+					codeEl.textContent = '';
+				}
+			} );
+			return;
+		}
+	} );
+}() );

--- a/includes/class-elc-link-checker.php
+++ b/includes/class-elc-link-checker.php
@@ -1,9 +1,29 @@
 <?php
 /**
- * Broken-link cron: weekly HEAD checks on external link inventory.
+ * Broken-link cron: weekly checks on external link inventory.
  *
- * Scans post content for external URLs, issues HEAD requests, and surfaces
- * 4xx/5xx results in a WP admin notice + a dismissible dashboard widget.
+ * Scans published post content for external URLs, issues HEAD requests (with a
+ * GET fallback for HEAD-hostile servers), and sorts the results into two
+ * buckets:
+ *
+ *   - broken     — the link is genuinely gone (404 / 410) or its host no longer
+ *                  resolves (a dead domain). These drive the admin notice and
+ *                  the headline count.
+ *   - unverified — the server answered, but in a way that means "I exist, I'm
+ *                  just not letting a bot confirm it": 401 / 403 / 405 / 429 /
+ *                  451 / 999, every other non-2xx/3xx, and transient network
+ *                  errors (timeouts, TLS handshake failures). These are shown
+ *                  for transparency but never raise the notice. LinkedIn
+ *                  (405 to HEAD) and time.com (403 to bots) live here.
+ *
+ * Two site-owner controls sit on top of the scan:
+ *
+ *   - an ignore list (`timu_elc_broken_link_ignored`) of URLs or bare hosts the
+ *     owner has chosen to stop hearing about; ignored entries are skipped at
+ *     collection time so they cost no request and never surface; and
+ *   - a dismissed-set fingerprint stored on the results option, so once the
+ *     notice is dismissed it stays dismissed until a *later* scan finds a URL
+ *     that wasn't in the dismissed set — not every time the same links recur.
  *
  * @package TIMU_ELC
  */
@@ -13,7 +33,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * ELC_Link_Checker manages the weekly broken-link HEAD-check cron event.
+ * ELC_Link_Checker manages the weekly broken-link cron event, the admin
+ * notice, the dashboard widget, the ignore list, and the AJAX actions that
+ * back the widget's buttons.
  */
 class ELC_Link_Checker {
 
@@ -32,14 +54,28 @@ class ELC_Link_Checker {
 	const RESULTS_OPTION = 'timu_elc_broken_link_results';
 
 	/**
-	 * Maximum external URLs to HEAD-check per run (prevents timeout).
+	 * Option key that stores the owner's ignore list (URLs and bare hosts).
+	 *
+	 * @var string
+	 */
+	const IGNORE_OPTION = 'timu_elc_broken_link_ignored';
+
+	/**
+	 * Shared nonce action for every widget/notice AJAX action.
+	 *
+	 * @var string
+	 */
+	const NONCE_ACTION = 'timu_elc_link_actions';
+
+	/**
+	 * Maximum external URLs to check per run (prevents timeout).
 	 *
 	 * @var int
 	 */
 	const MAX_URLS_PER_RUN = 200;
 
 	/**
-	 * HTTP timeout in seconds for each HEAD request.
+	 * HTTP timeout in seconds for each request.
 	 *
 	 * @var int
 	 */
@@ -53,7 +89,13 @@ class ELC_Link_Checker {
 		add_action( 'admin_init', array( $this, 'schedule_if_needed' ) );
 		add_action( 'admin_notices', array( $this, 'maybe_render_admin_notice' ) );
 		add_action( 'wp_dashboard_setup', array( $this, 'register_dashboard_widget' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+
 		add_action( 'wp_ajax_timu_elc_dismiss_notice', array( $this, 'ajax_dismiss_notice' ) );
+		add_action( 'wp_ajax_timu_elc_ignore_link', array( $this, 'ajax_ignore_link' ) );
+		add_action( 'wp_ajax_timu_elc_unignore_link', array( $this, 'ajax_unignore_link' ) );
+		add_action( 'wp_ajax_timu_elc_recheck_link', array( $this, 'ajax_recheck_link' ) );
+		add_action( 'wp_ajax_timu_elc_scan_now', array( $this, 'ajax_scan_now' ) );
 	}
 
 	/**
@@ -75,69 +117,190 @@ class ELC_Link_Checker {
 		}
 	}
 
+	/* ---------------------------------------------------------------------
+	 * The scan
+	 * ------------------------------------------------------------------- */
+
 	/**
-	 * Run the HEAD-check scan. Invoked by the cron event.
+	 * Run the scan. Invoked by the cron event and by the "Scan now" action.
 	 */
 	public function run_check() {
 		$urls = $this->collect_external_urls();
 		if ( empty( $urls ) ) {
+			// Nothing left to check — clear stale broken results so the notice
+			// doesn't outlive the content that produced it.
+			$this->store_results( array(), array(), 0 );
 			return;
 		}
 
-		$broken = array();
+		$broken     = array();
+		$unverified = array();
 
 		foreach ( $urls as $url => $post_ids ) {
-			$response = wp_remote_head(
-				$url,
-				array(
-					'timeout'    => self::REQUEST_TIMEOUT,
-					'user-agent' => 'Mozilla/5.0 (compatible; TIMU-ELC-LinkChecker/1.0; +https://thisismyurl.com/)',
-					'sslverify'  => true,
-					'redirection' => 3,
-				)
-			);
+			$result = $this->check_url( $url );
 
-			if ( is_wp_error( $response ) ) {
-				$broken[ $url ] = array(
-					'status'   => 0,
-					'message'  => $response->get_error_message(),
-					'post_ids' => $post_ids,
-				);
+			if ( 'ok' === $result['verdict'] ) {
 				continue;
 			}
 
-			$status = (int) wp_remote_retrieve_response_code( $response );
+			$entry = array(
+				'status'   => $result['status'],
+				'message'  => $result['message'],
+				'post_ids' => $post_ids,
+			);
 
-			// 4xx and 5xx are broken; treat 0 as unknown error.
-			if ( $status >= 400 || 0 === $status ) {
-				$broken[ $url ] = array(
-					'status'   => $status,
-					'message'  => wp_remote_retrieve_response_message( $response ),
-					'post_ids' => $post_ids,
-				);
+			if ( 'broken' === $result['verdict'] ) {
+				$broken[ $url ] = $entry;
+			} else {
+				$unverified[ $url ] = $entry;
 			}
 		}
 
-		// Persist results with the run timestamp.
+		$this->store_results( $broken, $unverified, count( $urls ) );
+	}
+
+	/**
+	 * Persist results, carrying the dismissed-set fingerprint forward.
+	 *
+	 * The dismissed set is intersected with the *current* broken set: a URL
+	 * that was dismissed and is still broken stays dismissed; a URL that is no
+	 * longer broken drops out of the fingerprint (so if it breaks again later
+	 * it is treated as new). A broken URL that was never dismissed is, by
+	 * definition, not in the fingerprint, so the notice will show for it.
+	 *
+	 * @param array<string,array<string,mixed>> $broken     Broken URL map.
+	 * @param array<string,array<string,mixed>> $unverified Unverified URL map.
+	 * @param int                                $checked    URLs checked.
+	 * @return void
+	 */
+	private function store_results( $broken, $unverified, $checked ) {
+		$previous       = get_option( self::RESULTS_OPTION );
+		$dismissed_urls = $this->dismissed_urls( is_array( $previous ) ? $previous : array() );
+
+		// Keep only fingerprints that are still broken.
+		$dismissed_urls = array_values( array_intersect( $dismissed_urls, array_keys( $broken ) ) );
+
 		update_option(
 			self::RESULTS_OPTION,
 			array(
-				'checked_at' => time(),
-				'checked'    => count( $urls ),
-				'broken'     => $broken,
-				'dismissed'  => false,
+				'checked_at'     => time(),
+				'checked'        => (int) $checked,
+				'broken'         => $broken,
+				'unverified'     => $unverified,
+				'dismissed_urls' => $dismissed_urls,
 			),
 			false
 		);
 	}
 
 	/**
-	 * Collect up to MAX_URLS_PER_RUN unique external URLs from published posts.
+	 * Issue a HEAD request, falling back to GET when the server is HEAD-hostile,
+	 * and classify the outcome.
+	 *
+	 * @param string $url URL to check.
+	 * @return array{status:int,message:string,verdict:string}
+	 */
+	private function check_url( $url ) {
+		$args = array(
+			'timeout'     => self::REQUEST_TIMEOUT,
+			'user-agent'  => 'Mozilla/5.0 (compatible; TIMU-ELC-LinkChecker/1.1; +https://thisismyurl.com/)',
+			'sslverify'   => true,
+			'redirection' => 3,
+		);
+
+		$response = wp_remote_head( $url, $args );
+		$status   = is_wp_error( $response ) ? 0 : (int) wp_remote_retrieve_response_code( $response );
+
+		// HEAD-hostile servers (and a few proxies) answer HEAD with a method or
+		// generic-client error even though GET is fine. Retry once with GET,
+		// asking for a single byte so we don't pull the whole body.
+		if ( is_wp_error( $response ) || in_array( $status, array( 400, 403, 405, 406, 501 ), true ) ) {
+			$get_args            = $args;
+			$get_args['headers'] = array( 'Range' => 'bytes=0-0' );
+			$get                 = wp_remote_get( $url, $get_args );
+
+			if ( ! is_wp_error( $get ) ) {
+				$response = $get;
+				$status   = (int) wp_remote_retrieve_response_code( $get );
+			} elseif ( ! is_wp_error( $response ) ) {
+				// Keep the HEAD response if only the GET retry errored.
+				$status = (int) wp_remote_retrieve_response_code( $response );
+			} else {
+				$response = $get;
+				$status   = 0;
+			}
+		}
+
+		return $this->classify( $response, $status );
+	}
+
+	/**
+	 * Classify a checked URL into ok / broken / unverified.
+	 *
+	 * @param array|WP_Error $response The (final) HTTP response or error.
+	 * @param int            $status   The (final) HTTP status code (0 on error).
+	 * @return array{status:int,message:string,verdict:string}
+	 */
+	private function classify( $response, $status ) {
+		if ( is_wp_error( $response ) ) {
+			$message = $response->get_error_message();
+
+			// A host that no longer resolves, or actively refuses the
+			// connection, is a dead link. A timeout or TLS failure is
+			// unverifiable — the host may simply be slow or fussy.
+			$dead = (bool) preg_match(
+				'/could ?n.?t resolve host|name or service not known|getaddrinfo|cURL error 6|cURL error 7|connection refused|no address associated/i',
+				$message
+			);
+
+			return array(
+				'status'  => 0,
+				'message' => $message,
+				'verdict' => $dead ? 'broken' : 'unverified',
+			);
+		}
+
+		$message = (string) wp_remote_retrieve_response_message( $response );
+
+		if ( $status >= 200 && $status < 400 ) {
+			return array(
+				'status'  => $status,
+				'message' => $message,
+				'verdict' => 'ok',
+			);
+		}
+
+		/**
+		 * Filter the status codes that count as genuinely broken.
+		 *
+		 * Defaults to 404 (Not Found) and 410 (Gone) — the two codes that mean
+		 * the resource is definitively no longer there. Everything else that
+		 * isn't a 2xx/3xx is treated as "unverified" rather than broken, so
+		 * bot-blocking (403), method restrictions (405), auth gates (401),
+		 * rate limits (429), and server errors (5xx) don't raise false alarms.
+		 *
+		 * @since 1.6148
+		 *
+		 * @param int[] $codes Broken status codes.
+		 */
+		$broken_codes = (array) apply_filters( 'timu_elc_broken_status_codes', array( 404, 410 ) );
+
+		return array(
+			'status'  => $status,
+			'message' => $message,
+			'verdict' => in_array( $status, array_map( 'intval', $broken_codes ), true ) ? 'broken' : 'unverified',
+		);
+	}
+
+	/**
+	 * Collect up to MAX_URLS_PER_RUN unique external URLs from published posts,
+	 * skipping anything on the ignore list.
 	 *
 	 * @return array<string, int[]> URL => [ post_id, ... ]
 	 */
 	private function collect_external_urls() {
 		$site_host = wp_parse_url( home_url(), PHP_URL_HOST );
+		$ignored   = $this->get_ignored();
 
 		$paged    = 1;
 		$all_urls = array();
@@ -178,6 +341,11 @@ class ELC_Link_Checker {
 					$normalised = strtolower( $raw_url );
 					$normalised = preg_replace( '/[?#].*$/', '', $normalised );
 
+					// Skip anything the owner has chosen to ignore.
+					if ( $this->matches_ignore( $normalised, $ignored ) ) {
+						continue;
+					}
+
 					if ( ! isset( $all_urls[ $normalised ] ) ) {
 						$all_urls[ $normalised ] = array();
 					}
@@ -203,8 +371,85 @@ class ELC_Link_Checker {
 		return $all_urls;
 	}
 
+	/* ---------------------------------------------------------------------
+	 * The ignore list
+	 * ------------------------------------------------------------------- */
+
 	/**
-	 * Show an admin notice when broken links are found (unless dismissed).
+	 * Return the ignore list — a flat array of normalised URLs and bare hosts.
+	 *
+	 * @return string[]
+	 */
+	public function get_ignored() {
+		$raw = get_option( self::IGNORE_OPTION, array() );
+		return is_array( $raw ) ? array_values( array_unique( array_filter( array_map( 'strval', $raw ) ) ) ) : array();
+	}
+
+	/**
+	 * Does a normalised URL match any ignore entry?
+	 *
+	 * An entry matches when it equals the URL exactly, or when it is a bare
+	 * host (no slash) that equals the URL's host with any leading `www.`
+	 * stripped from both sides.
+	 *
+	 * @param string   $url     Normalised (lowercased, query-stripped) URL.
+	 * @param string[] $ignored Ignore list.
+	 * @return bool
+	 */
+	private function matches_ignore( $url, $ignored ) {
+		if ( empty( $ignored ) ) {
+			return false;
+		}
+
+		$url_host = (string) wp_parse_url( $url, PHP_URL_HOST );
+		$url_host = preg_replace( '/^www\./', '', strtolower( $url_host ) );
+
+		foreach ( $ignored as $entry ) {
+			$entry = strtolower( trim( $entry ) );
+			if ( '' === $entry ) {
+				continue;
+			}
+			// Exact-URL match.
+			if ( $entry === $url ) {
+				return true;
+			}
+			// Bare-host match (entry carries no path).
+			if ( false === strpos( $entry, '/' ) ) {
+				$entry_host = preg_replace( '/^www\./', '', $entry );
+				if ( '' !== $entry_host && $entry_host === $url_host ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Normalise a single ignore candidate. A full URL is lowercased and has its
+	 * query/fragment stripped; a bare host is lowercased and trimmed.
+	 *
+	 * @param string $candidate Raw user input.
+	 * @return string Normalised entry, or '' if unusable.
+	 */
+	private function normalise_ignore_entry( $candidate ) {
+		$candidate = strtolower( trim( (string) $candidate ) );
+		if ( '' === $candidate ) {
+			return '';
+		}
+		if ( 0 === strpos( $candidate, 'http://' ) || 0 === strpos( $candidate, 'https://' ) ) {
+			return (string) preg_replace( '/[?#].*$/', '', $candidate );
+		}
+		// Treat anything else as a bare host; strip a stray trailing slash.
+		return rtrim( $candidate, '/' );
+	}
+
+	/* ---------------------------------------------------------------------
+	 * The admin notice
+	 * ------------------------------------------------------------------- */
+
+	/**
+	 * Show an admin notice when undismissed broken links exist.
 	 */
 	public function maybe_render_admin_notice() {
 		if ( ! current_user_can( 'manage_options' ) ) {
@@ -212,18 +457,20 @@ class ELC_Link_Checker {
 		}
 
 		$results = get_option( self::RESULTS_OPTION );
-		if ( ! is_array( $results ) || empty( $results['broken'] ) || ! empty( $results['dismissed'] ) ) {
+		if ( ! is_array( $results ) ) {
 			return;
 		}
 
-		$count    = count( $results['broken'] );
-		$when     = human_time_diff( (int) $results['checked_at'], time() );
-		$nonce    = wp_create_nonce( 'timu_elc_dismiss_notice' );
-		$dismiss  = esc_url( admin_url( 'admin-ajax.php?action=timu_elc_dismiss_notice&_wpnonce=' . $nonce ) );
+		$undismissed = $this->undismissed_broken( $results );
+		if ( empty( $undismissed ) ) {
+			return;
+		}
+
+		$count = count( $undismissed );
+		$when  = isset( $results['checked_at'] ) ? human_time_diff( (int) $results['checked_at'], time() ) : '';
 
 		printf(
-			'<div class="notice notice-warning is-dismissible timu-elc-broken-notice" data-dismiss-url="%s"><p><strong>%s</strong> %s <a href="%s">%s</a></p></div>',
-			esc_attr( $dismiss ),
+			'<div class="notice notice-warning is-dismissible timu-elc-broken-notice"><p><strong>%s</strong> %s <a href="%s">%s</a></p></div>',
 			esc_html(
 				sprintf(
 					/* translators: %d: number of broken links found. */
@@ -231,17 +478,71 @@ class ELC_Link_Checker {
 					$count
 				)
 			),
-			esc_html(
-				sprintf(
-					/* translators: %s: human-readable time delta, e.g. "2 days". */
-					__( '%s ago.', 'thisismyurl-external-link-control' ),
-					$when
+			$when
+				? esc_html(
+					sprintf(
+						/* translators: %s: human-readable time delta, e.g. "2 days". */
+						__( '(last scan %s ago).', 'thisismyurl-external-link-control' ),
+						$when
+					)
 				)
-			),
+				: '',
 			esc_url( admin_url( 'index.php#timu-elc-broken-links' ) ),
-			esc_html__( 'View broken links', 'thisismyurl-external-link-control' )
+			esc_html__( 'Review them', 'thisismyurl-external-link-control' )
 		);
 	}
+
+	/**
+	 * The broken URLs that are neither ignored nor in the dismissed set.
+	 *
+	 * @param array<string,mixed> $results Stored results option.
+	 * @return string[] Undismissed broken URLs.
+	 */
+	private function undismissed_broken( $results ) {
+		$broken = isset( $results['broken'] ) && is_array( $results['broken'] ) ? array_keys( $results['broken'] ) : array();
+		if ( empty( $broken ) ) {
+			return array();
+		}
+
+		$dismissed = $this->dismissed_urls( $results );
+		$ignored   = $this->get_ignored();
+
+		$out = array();
+		foreach ( $broken as $url ) {
+			if ( in_array( $url, $dismissed, true ) ) {
+				continue;
+			}
+			if ( $this->matches_ignore( $url, $ignored ) ) {
+				continue;
+			}
+			$out[] = $url;
+		}
+		return $out;
+	}
+
+	/**
+	 * Read the dismissed-URL fingerprint, tolerating the legacy boolean shape.
+	 *
+	 * Before 1.6148 the option stored `dismissed => true|false`. A legacy
+	 * `true` means "the owner dismissed everything that was broken then", so we
+	 * treat every currently-broken URL as dismissed for that one transition.
+	 *
+	 * @param array<string,mixed> $results Stored results option.
+	 * @return string[]
+	 */
+	private function dismissed_urls( $results ) {
+		if ( isset( $results['dismissed_urls'] ) && is_array( $results['dismissed_urls'] ) ) {
+			return array_values( array_filter( array_map( 'strval', $results['dismissed_urls'] ) ) );
+		}
+		if ( ! empty( $results['dismissed'] ) && isset( $results['broken'] ) && is_array( $results['broken'] ) ) {
+			return array_keys( $results['broken'] );
+		}
+		return array();
+	}
+
+	/* ---------------------------------------------------------------------
+	 * The dashboard widget
+	 * ------------------------------------------------------------------- */
 
 	/**
 	 * Register the broken-links dashboard widget.
@@ -264,59 +565,103 @@ class ELC_Link_Checker {
 	public function render_dashboard_widget() {
 		$results = get_option( self::RESULTS_OPTION );
 
+		echo '<div class="timu-elc-widget" id="timu-elc-broken-links">';
+
 		if ( ! is_array( $results ) ) {
-			echo '<p>' . esc_html__( 'No scan has been run yet. A scan runs automatically every week.', 'thisismyurl-external-link-control' ) . '</p>';
+			echo '<p>' . esc_html__( 'No scan has run yet. A scan runs automatically every week.', 'thisismyurl-external-link-control' ) . '</p>';
+			$this->render_scan_button();
+			echo '</div>';
 			return;
 		}
 
 		$checked_at = isset( $results['checked_at'] ) ? (int) $results['checked_at'] : 0;
 		$broken     = isset( $results['broken'] ) && is_array( $results['broken'] ) ? $results['broken'] : array();
+		$unverified = isset( $results['unverified'] ) && is_array( $results['unverified'] ) ? $results['unverified'] : array();
 		$checked    = isset( $results['checked'] ) ? (int) $results['checked'] : 0;
 
-		echo '<p>';
+		echo '<p class="timu-elc-last-scan">';
 		printf(
 			/* translators: 1: number of URLs checked, 2: human-readable date. */
 			esc_html__( 'Last scan: %1$d URLs checked on %2$s.', 'thisismyurl-external-link-control' ),
 			(int) $checked,
-			esc_html( wp_date( get_option( 'date_format' ), $checked_at ) )
+			esc_html( $checked_at ? wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $checked_at ) : '—' )
 		);
 		echo '</p>';
 
+		$this->render_scan_button();
+
 		if ( empty( $broken ) ) {
-			echo '<p>' . esc_html__( 'No broken links found.', 'thisismyurl-external-link-control' ) . '</p>';
-			return;
+			echo '<p class="timu-elc-clear">' . esc_html__( 'No broken links found.', 'thisismyurl-external-link-control' ) . '</p>';
+		} else {
+			echo '<h4>';
+			printf(
+				/* translators: %d: number of broken links. */
+				esc_html( _n( '%d broken link', '%d broken links', count( $broken ), 'thisismyurl-external-link-control' ) ),
+				(int) count( $broken )
+			);
+			echo '</h4>';
+			$this->render_link_list( $broken, 'broken' );
 		}
 
-		echo '<p><strong>';
-		printf(
-			/* translators: %d: number of broken links. */
-			esc_html( _n( '%d broken link found:', '%d broken links found:', count( $broken ), 'thisismyurl-external-link-control' ) ),
-			(int) count( $broken )
-		);
-		echo '</strong></p>';
-		echo '<ul id="timu-elc-broken-links">';
+		if ( ! empty( $unverified ) ) {
+			echo '<h4 class="timu-elc-unverified-head">' . esc_html__( 'Could not verify', 'thisismyurl-external-link-control' ) . '</h4>';
+			echo '<p class="description">' . esc_html__( 'These answered, but blocked the check (bot protection, rate limit, login wall, or a server error). They are most likely fine.', 'thisismyurl-external-link-control' ) . '</p>';
+			$this->render_link_list( $unverified, 'unverified' );
+		}
 
-		foreach ( array_slice( $broken, 0, 20 ) as $url => $info ) {
-			$status    = (int) $info['status'];
-			$post_ids  = is_array( $info['post_ids'] ) ? $info['post_ids'] : array();
-			$post_edit = ! empty( $post_ids )
-				? admin_url( 'post.php?post=' . (int) $post_ids[0] . '&action=edit' )
-				: '';
+		$this->render_ignored_list();
+
+		echo '</div>';
+	}
+
+	/**
+	 * Render the "Scan now" button.
+	 */
+	private function render_scan_button() {
+		printf(
+			'<p class="timu-elc-actions"><button type="button" class="button button-secondary timu-elc-scan-now">%s</button> <span class="timu-elc-status" role="status" aria-live="polite"></span></p>',
+			esc_html__( 'Scan now', 'thisismyurl-external-link-control' )
+		);
+	}
+
+	/**
+	 * Render a list of checked links with per-row actions.
+	 *
+	 * @param array<string,array<string,mixed>> $items  URL => info map.
+	 * @param string                            $bucket 'broken' or 'unverified'.
+	 * @return void
+	 */
+	private function render_link_list( $items, $bucket ) {
+		echo '<ul class="timu-elc-link-list timu-elc-' . esc_attr( $bucket ) . '">';
+
+		$shown = 0;
+		foreach ( $items as $url => $info ) {
+			if ( $shown >= 25 ) {
+				break;
+			}
+			$shown++;
+
+			$status   = isset( $info['status'] ) ? (int) $info['status'] : 0;
+			$post_ids = isset( $info['post_ids'] ) && is_array( $info['post_ids'] ) ? $info['post_ids'] : array();
+			$edit     = ! empty( $post_ids ) ? admin_url( 'post.php?post=' . (int) $post_ids[0] . '&action=edit' ) : '';
 
 			printf(
-				'<li><code>%s</code> &mdash; HTTP %s%s</li>',
+				'<li data-url="%s"><code>%s</code> <span class="timu-elc-code">HTTP %s</span>%s <span class="timu-elc-row-actions">%s<button type="button" class="button-link timu-elc-ignore">%s</button></span></li>',
+				esc_attr( $url ),
 				esc_html( $url ),
 				$status ? esc_html( (string) $status ) : esc_html__( 'error', 'thisismyurl-external-link-control' ),
-				$post_edit ? sprintf( ' (<a href="%s">%s</a>)', esc_url( $post_edit ), esc_html__( 'first post', 'thisismyurl-external-link-control' ) ) : ''
+				$edit ? sprintf( ' (<a href="%s">%s</a>)', esc_url( $edit ), esc_html__( 'edit post', 'thisismyurl-external-link-control' ) ) : '',
+				sprintf( '<button type="button" class="button-link timu-elc-recheck">%s</button> ', esc_html__( 'Recheck', 'thisismyurl-external-link-control' ) ),
+				esc_html__( 'Ignore', 'thisismyurl-external-link-control' )
 			);
 		}
 
-		if ( count( $broken ) > 20 ) {
-			echo '<li><em>' . esc_html(
+		if ( count( $items ) > $shown ) {
+			echo '<li class="timu-elc-more"><em>' . esc_html(
 				sprintf(
-					/* translators: %d: number of additional broken links not shown. */
+					/* translators: %d: number of additional links not shown. */
 					__( '…and %d more.', 'thisismyurl-external-link-control' ),
-					count( $broken ) - 20
+					count( $items ) - $shown
 				)
 			) . '</em></li>';
 		}
@@ -325,21 +670,264 @@ class ELC_Link_Checker {
 	}
 
 	/**
-	 * AJAX: dismiss the admin notice by flagging results as dismissed.
+	 * Render the ignore list with "Stop ignoring" actions.
+	 */
+	private function render_ignored_list() {
+		$ignored = $this->get_ignored();
+		if ( empty( $ignored ) ) {
+			return;
+		}
+
+		echo '<h4 class="timu-elc-ignored-head">' . esc_html__( 'Ignored', 'thisismyurl-external-link-control' ) . '</h4>';
+		echo '<ul class="timu-elc-link-list timu-elc-ignored">';
+		foreach ( $ignored as $entry ) {
+			printf(
+				'<li data-url="%s"><code>%s</code> <span class="timu-elc-row-actions"><button type="button" class="button-link timu-elc-unignore">%s</button></span></li>',
+				esc_attr( $entry ),
+				esc_html( $entry ),
+				esc_html__( 'Stop ignoring', 'thisismyurl-external-link-control' )
+			);
+		}
+		echo '</ul>';
+	}
+
+	/* ---------------------------------------------------------------------
+	 * Assets
+	 * ------------------------------------------------------------------- */
+
+	/**
+	 * Enqueue the widget/notice JS (and the shared admin CSS) wherever the
+	 * notice or widget can appear. The notice can show on any admin screen, so
+	 * the script loads admin-wide for capable users; it is tiny.
+	 *
+	 * @param string $hook Current admin page hook.
+	 * @return void
+	 */
+	public function enqueue_assets( $hook ) {
+		unset( $hook );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$base = plugin_dir_url( dirname( __FILE__ ) );
+
+		wp_enqueue_style(
+			'timu-elc-admin',
+			$base . 'assets/css/admin.css',
+			array(),
+			'1.6148'
+		);
+
+		wp_enqueue_script(
+			'timu-elc-admin',
+			$base . 'assets/js/admin.js',
+			array(),
+			'1.6148',
+			true
+		);
+
+		wp_localize_script(
+			'timu-elc-admin',
+			'timuElc',
+			array(
+				'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+				'nonce'   => wp_create_nonce( self::NONCE_ACTION ),
+				'i18n'    => array(
+					'scanning'  => __( 'Scanning… this can take a minute. Refresh to see results.', 'thisismyurl-external-link-control' ),
+					'scanError' => __( 'Could not start the scan. Please try again.', 'thisismyurl-external-link-control' ),
+					'rechecking' => __( 'Rechecking…', 'thisismyurl-external-link-control' ),
+				),
+			)
+		);
+	}
+
+	/* ---------------------------------------------------------------------
+	 * AJAX actions
+	 * ------------------------------------------------------------------- */
+
+	/**
+	 * Shared guard: verify nonce + capability, or die.
+	 *
+	 * @return void
+	 */
+	private function verify_request() {
+		check_ajax_referer( self::NONCE_ACTION, 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Permission denied.', 'thisismyurl-external-link-control' ) ), 403 );
+		}
+	}
+
+	/**
+	 * Read and normalise the `url` parameter from the request.
+	 *
+	 * @return string Normalised URL/host, or '' if absent.
+	 */
+	private function request_url() {
+		$raw = isset( $_POST['url'] ) ? wp_unslash( $_POST['url'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitized
+		$raw = is_string( $raw ) ? trim( $raw ) : '';
+		if ( '' === $raw ) {
+			return '';
+		}
+		// URLs are stored lowercased + query-stripped; mirror that here.
+		$lower = strtolower( $raw );
+		if ( 0 === strpos( $lower, 'http://' ) || 0 === strpos( $lower, 'https://' ) ) {
+			return (string) preg_replace( '/[?#].*$/', '', $lower );
+		}
+		return rtrim( $lower, '/' );
+	}
+
+	/**
+	 * AJAX: dismiss the notice by fingerprinting the current broken set.
 	 */
 	public function ajax_dismiss_notice() {
-		check_ajax_referer( 'timu_elc_dismiss_notice' );
-
-		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_die( '', '', array( 'response' => 403 ) );
-		}
+		$this->verify_request();
 
 		$results = get_option( self::RESULTS_OPTION );
 		if ( is_array( $results ) ) {
-			$results['dismissed'] = true;
+			// Dismiss exactly what is broken now; a later scan that finds a new
+			// URL will not be in this set, so the notice returns for it.
+			$results['dismissed_urls'] = isset( $results['broken'] ) && is_array( $results['broken'] )
+				? array_keys( $results['broken'] )
+				: array();
+			unset( $results['dismissed'] ); // Retire the legacy boolean.
 			update_option( self::RESULTS_OPTION, $results, false );
 		}
 
 		wp_send_json_success();
+	}
+
+	/**
+	 * AJAX: add a URL/host to the ignore list and drop it from results.
+	 */
+	public function ajax_ignore_link() {
+		$this->verify_request();
+
+		$entry = $this->normalise_ignore_entry( $this->request_url() );
+		if ( '' === $entry ) {
+			wp_send_json_error( array( 'message' => __( 'No URL supplied.', 'thisismyurl-external-link-control' ) ) );
+		}
+
+		$ignored = $this->get_ignored();
+		if ( ! in_array( $entry, $ignored, true ) ) {
+			$ignored[] = $entry;
+			update_option( self::IGNORE_OPTION, array_values( $ignored ), false );
+		}
+
+		// Remove it from the live result buckets and the dismissed fingerprint.
+		$results = get_option( self::RESULTS_OPTION );
+		if ( is_array( $results ) ) {
+			foreach ( array( 'broken', 'unverified' ) as $bucket ) {
+				if ( isset( $results[ $bucket ] ) && is_array( $results[ $bucket ] ) ) {
+					foreach ( array_keys( $results[ $bucket ] ) as $url ) {
+						if ( $this->matches_ignore( $url, array( $entry ) ) ) {
+							unset( $results[ $bucket ][ $url ] );
+						}
+					}
+				}
+			}
+			if ( isset( $results['dismissed_urls'] ) && is_array( $results['dismissed_urls'] ) ) {
+				$results['dismissed_urls'] = array_values(
+					array_filter(
+						$results['dismissed_urls'],
+						function ( $url ) use ( $entry ) {
+							return ! $this->matches_ignore( (string) $url, array( $entry ) );
+						}
+					)
+				);
+			}
+			update_option( self::RESULTS_OPTION, $results, false );
+		}
+
+		wp_send_json_success( array( 'entry' => $entry ) );
+	}
+
+	/**
+	 * AJAX: remove a URL/host from the ignore list.
+	 */
+	public function ajax_unignore_link() {
+		$this->verify_request();
+
+		$entry   = $this->normalise_ignore_entry( $this->request_url() );
+		$ignored = $this->get_ignored();
+		$ignored = array_values(
+			array_filter(
+				$ignored,
+				static function ( $e ) use ( $entry ) {
+					return $e !== $entry;
+				}
+			)
+		);
+		update_option( self::IGNORE_OPTION, $ignored, false );
+
+		wp_send_json_success( array( 'entry' => $entry ) );
+	}
+
+	/**
+	 * AJAX: recheck a single URL now and report the new verdict.
+	 */
+	public function ajax_recheck_link() {
+		$this->verify_request();
+
+		$url = $this->request_url();
+		if ( '' === $url ) {
+			wp_send_json_error( array( 'message' => __( 'No URL supplied.', 'thisismyurl-external-link-control' ) ) );
+		}
+
+		$result = $this->check_url( $url );
+
+		// Move the URL into its correct bucket in the stored results.
+		$results = get_option( self::RESULTS_OPTION );
+		if ( is_array( $results ) ) {
+			$post_ids = array();
+			foreach ( array( 'broken', 'unverified' ) as $bucket ) {
+				if ( isset( $results[ $bucket ][ $url ]['post_ids'] ) ) {
+					$post_ids = (array) $results[ $bucket ][ $url ]['post_ids'];
+				}
+				unset( $results[ $bucket ][ $url ] );
+			}
+
+			if ( 'ok' !== $result['verdict'] ) {
+				$target = ( 'broken' === $result['verdict'] ) ? 'broken' : 'unverified';
+				if ( ! isset( $results[ $target ] ) || ! is_array( $results[ $target ] ) ) {
+					$results[ $target ] = array();
+				}
+				$results[ $target ][ $url ] = array(
+					'status'   => $result['status'],
+					'message'  => $result['message'],
+					'post_ids' => $post_ids,
+				);
+			}
+			update_option( self::RESULTS_OPTION, $results, false );
+		}
+
+		wp_send_json_success(
+			array(
+				'url'     => $url,
+				'status'  => $result['status'],
+				'verdict' => $result['verdict'],
+			)
+		);
+	}
+
+	/**
+	 * AJAX: run a scan now.
+	 *
+	 * A full scan makes up to MAX_URLS_PER_RUN external requests, which is too
+	 * slow to block a browser request on. Instead we schedule the cron event to
+	 * fire immediately and spawn the cron runner; the JS tells the owner to
+	 * refresh shortly. On environments with WP-Cron disabled we fall back to
+	 * running the scan inline.
+	 */
+	public function ajax_scan_now() {
+		$this->verify_request();
+
+		if ( defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON ) {
+			$this->run_check();
+			wp_send_json_success( array( 'mode' => 'inline' ) );
+		}
+
+		wp_schedule_single_event( time(), self::CRON_HOOK );
+		spawn_cron();
+		wp_send_json_success( array( 'mode' => 'scheduled' ) );
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: external links, nofollow, target blank, seo, link management
 Requires at least: 6.2
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 1.6147
+Stable tag: 1.6148
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -88,6 +88,15 @@ I review PRs thoughtfully and appreciate well-tested contributions. Contributing
 
 == Changelog ==
 
+= 1.6148 =
+* Fix: the broken-link admin notice now stays dismissed. Earlier versions shipped no JavaScript, so WordPress's dismiss "X" only hid the notice for that page load and never told the server — it reappeared on the next screen. Dismissing now records which links were dismissed; the notice only returns when a later scan finds a link that was not in the dismissed set.
+* Fix: far fewer false positives. A 401, 403, 405, 429, 451, or 999 response (login walls, bot protection, rate limits, servers that reject HEAD) is no longer reported as broken — these mean "the link exists, I just won't let an automated checker confirm it." Only 404, 410, and dead domains (a host that no longer resolves) count as broken. HEAD requests that fail now retry once with GET before any verdict, so HEAD-hostile servers stop showing up as broken.
+* New: an ignore list. Use the "Ignore" button next to any link in the Broken Links dashboard widget to stop hearing about a URL or a whole host; manage it from the same widget ("Stop ignoring"). Ignored links are skipped during the scan, so they cost no request.
+* New: a "Scan now" button in the dashboard widget — run the check on demand instead of waiting for the weekly cron.
+* New: a "Could not verify" section in the widget lists links that answered but blocked the check, for transparency, without raising the notice.
+* New: per-link "Recheck" button to re-test a single URL immediately.
+* New: `timu_elc_broken_status_codes` filter to tune which HTTP status codes count as broken (defaults to 404 and 410).
+
 = 1.6147 =
 * Unified plugin versioning to the x.Yddd calendar-version scheme.
 * Confirmed compatibility with WordPress 7.0.
@@ -122,6 +131,9 @@ I review PRs thoughtfully and appreciate well-tested contributions. Contributing
 * Initial release
 
 == Upgrade Notice ==
+
+= 1.6148 =
+Broken-link checker overhaul: notice dismissals now stick, an ignore list lets you mute links you do not care about, a "Scan now" button runs the check on demand, and false positives (403/405/429 and HEAD-hostile servers like LinkedIn) are no longer reported as broken. Only genuine 404/410/dead-domain links raise the notice.
 
 = 0.6123 =
 Major audit-driven overhaul. Adds per-domain rules, rel="ugc" on comments, rel="sponsored" support, FSE block coverage, render-time caching, accessibility text on forced new-tab links, and WP-CLI commands. Fixes a subdomain-misclassification bug in the internal-link detection, ensures `noopener noreferrer` always lands on `target="_blank"`, and stops mutating links inside `<code>` / `<pre>` / JSON-LD blocks. Minimum WP raised to 6.2.

--- a/thisismyurl-external-link-control.php
+++ b/thisismyurl-external-link-control.php
@@ -3,7 +3,7 @@
  * Plugin Name:       This Is My URL - External Link Control
  * Plugin URI:        https://thisismyurl.com/external-link-control
  * Description:       Globally manage external link behavior, including nofollow and target attributes.
- * Version:           1.6147
+ * Version:           1.6148
  * Requires at least: 6.2
  * Requires PHP:      7.4
  * Author:            Christopher Ross
@@ -125,7 +125,7 @@ class TIMU_ELC {
                 'timu-elc-admin',
                 plugins_url( 'assets/css/admin.css', __FILE__ ),
                 array(),
-                '1.6147'
+                '1.6148'
             );
         }
     }


### PR DESCRIPTION
## What this does

Fixes three long-standing problems with the weekly broken-link checker and adds the controls it was missing. Based on `origin/main` @ 1.6147; ships as the next calendar version **1.6148**.

### Fixed
- **Persistent dismissal.** The plugin shipped no JavaScript, so the core `is-dismissible` "X" only hid the notice client-side and never called the dismiss endpoint — it reappeared on the next admin screen. New `assets/js/admin.js` records the dismissal server-side.
- **Dismissals remembered per link-set.** A `dismissed_urls` fingerprint replaces the single boolean; the notice only returns when a later scan finds a genuinely new break, not every time the same known links recur.
- **Far fewer false positives.** Only `404` / `410` / dead-domain count as broken. `401/403/405/429/451/999`, other non-2xx/3xx, and transient network errors fall into a non-alarming **"Could not verify"** bucket. HEAD failures retry once with a ranged GET, so HEAD-hostile servers (LinkedIn, etc.) are no longer mislabelled.

### Added
- Ignore list (URL or whole host), **Scan now**, per-link **Recheck**, "Could not verify" section, and the `timu_elc_broken_status_codes` filter.

## Safety
- All AJAX actions nonce-verified (`timu_elc_link_actions`) + capability-gated (`manage_options`).
- Widget JS + admin CSS enqueue admin-wide for capable users (notice can appear on any screen); asset is small.

## Testing
- `php -l` clean (PHP 7.4-compatible — no PHP-8-only syntax).
- Classification verified against 12 real URLs: LinkedIn → OK (HEAD 405 → GET 206), time.com → could-not-verify (403), dead domain → broken (0), genuine 404s → broken.
- 11/11 logic assertions pass (ignore matching incl. www-insensitivity, dismissed-fingerprint, legacy-boolean migration).
- Fresh full scan on a live site: stale data replaced, 0 broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)