### PR TITLE
chore: add CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Code of Conduct
+
+## Our Commitment
+
+This project aims to be a community where people can participate safely, respectfully, and constructively.
+
+We want this community to reflect the same values as the work itself:
+
+- helpfulness
+- clarity
+- accessibility
+- respect
+- patience
+- privacy and safety awareness
+
+---
+
+## Expected Behavior
+
+Examples of positive community behavior include:
+
+- being respectful and kind
+- assuming good intent while still being clear about problems
+- welcoming beginners as well as experienced developers
+- giving actionable, specific feedback
+- using plain language where possible
+- respecting accessibility needs and diverse ways of working
+- focusing on solving the problem rather than scoring points
+
+---
+
+## Unacceptable Behavior
+
+Examples of unacceptable behavior include:
+
+- harassment or personal attacks
+- insulting, demeaning, or exclusionary language
+- intimidation or deliberate hostility
+- trolling or repeated bad-faith disruption
+- publishing private information without permission
+- discrimination based on identity, ability, culture, language, or background
+- using fear, shame, or manipulation to pressure others
+
+---
+
+## Enforcement Principles
+
+Project maintainers may remove, edit, or reject behavior that undermines the health of the community.
+
+We will try to respond in a way that is:
+
+- fair
+- proportionate
+- safety-conscious
+- consistent with the Helpful Neighbor philosophy
+
+---
+
+## Reporting Concerns
+
+If you experience or witness harmful behavior, please contact the maintainers through the project support/contact route and clearly mark the message as a code-of-conduct concern.
+
+For security-related concerns, use [`SECURITY.md`](SECURITY.md) instead.
+
+---
+
+## Scope
+
+This code of conduct applies to project spaces such as:
+
+- GitHub issues
+- pull requests
+- discussions
+- documentation contributions
+- community support interactions tied to the project
+
+---
+
+## Final Note
+
+A project about trust should also practice trustworthiness in how people are treated.
+
+That standard applies here too.


### PR DESCRIPTION
**TL;DR:** Adding the missing code of conduct to External Link Control — the other community health files (CONTRIBUTING.md and SECURITY.md) were already here but CODE_OF_CONDUCT.md got missed when the plugin line was set up. Consistent across all the thisismyurl plugin repos now. AI helped verify the content is consistent with the rest of the line.